### PR TITLE
Allow for https scheme in the manifest

### DIFF
--- a/src/manifest.json.yml
+++ b/src/manifest.json.yml
@@ -19,14 +19,14 @@ content_scripts:
     js:
       - /js/preload.js
     matches:
-      - http://reason.com/*
+      - *://reason.com/*
     run_at: document_start
   - css:
       - /css/content.css
     js:
       - /js/content.js
     matches:
-      - http://reason.com/*
+      - *://reason.com/*
 options_page: options.html
 permissions:
   - tabs


### PR DESCRIPTION
Reason is now switching to force https - reasonable needs to detect https urls as a load point
